### PR TITLE
Stop using absolute paths to run executables

### DIFF
--- a/install
+++ b/install
@@ -33,14 +33,18 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 if [ -z "$(command -v brew)" ];
 then
   echo "--> Installing homebrew"
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  echo '# Set PATH, MANPATH, etc., for Homebrew.' >> $HOME/.zprofile
+  echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> $HOME/.zprofile
+  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
 if [ -z "$(command -v rcup)" ];
 then
   echo "--> Installing rcm"
-  /usr/local/bin/brew tap thoughtbot/formulae
-  /usr/local/bin/brew install rcm
+  brew tap thoughtbot/formulae
+  brew install rcm
 fi
 
 # Company Dotfiles

--- a/install.d/aws.sh
+++ b/install.d/aws.sh
@@ -3,8 +3,8 @@
 # Install and configure AWS
 if [ -z "$(command -v aws-rotate-iam-keys)" ];
 then
-  /usr/local/bin/brew tap rhyeal/aws-rotate-iam-keys https://github.com/rhyeal/aws-rotate-iam-keys
-  /usr/local/bin/brew install awscli aws-rotate-iam-keys
+  brew tap rhyeal/aws-rotate-iam-keys https://github.com/rhyeal/aws-rotate-iam-keys
+  brew install awscli aws-rotate-iam-keys
   brew services start aws-rotate-iam-keys
 fi
 

--- a/post-install.d/aws.sh
+++ b/post-install.d/aws.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [ -z "$(/usr/local/bin/aws configure get aws_access_key_id)" ]; then
+if [ -z "$(aws configure get aws_access_key_id)" ]; then
   echo "AWS Credentials"
   echo "Visit https://console.aws.amazon.com/iam/home?region=eu-central-1#/security_credentials"
   echo ""
   read -p "Access Key ID: " aws_access_key_id
   read -p "Secret Access Key: " aws_secret_access_key
 
-  /usr/local/bin/aws configure set aws_access_key_id "${aws_access_key_id}"
-  /usr/local/bin/aws configure set aws_secret_access_key "${aws_secret_access_key}"
-  /usr/local/bin/aws configure set default.region eu-central-1
+  aws configure set aws_access_key_id "${aws_access_key_id}"
+  aws configure set aws_secret_access_key "${aws_secret_access_key}"
+  aws configure set default.region eu-central-1
 fi
 
 # Ensure Docker Credentials
@@ -21,7 +21,7 @@ then
     echo '{}' > ~/.docker/config.json
   fi
 
-  /usr/local/bin/brew install jq docker-credential-helper-ecr
+  brew install jq docker-credential-helper-ecr
 
   jq \
     '. + {"credsHelpers": {"003688427525.dkr.ecr.eu-central-1.amazonaws.com": "ecr-login"}}' \

--- a/post-install.d/aws.sh
+++ b/post-install.d/aws.sh
@@ -5,7 +5,8 @@ if [ -z "$(aws configure get aws_access_key_id)" ]; then
   echo "Visit https://console.aws.amazon.com/iam/home?region=eu-central-1#/security_credentials"
   echo ""
   read -p "Access Key ID: " aws_access_key_id
-  read -p "Secret Access Key: " aws_secret_access_key
+  echo "Secret Access Key: "
+  read -s aws_secret_access_key
 
   aws configure set aws_access_key_id "${aws_access_key_id}"
   aws configure set aws_secret_access_key "${aws_secret_access_key}"


### PR DESCRIPTION

## Summary

This PR should remove the absolute paths used to run executables.
This will also hide the AWS Secret Access Key that users input from the terminal output.

## Motivation and Context

The folder structure for Mac M1 has changed significantly so the absolute paths used to run executables in this repo no longer work. This PR should fix issues that I ran into when running the install script on Mac M1 and Manjaro Linux.

## Test Plan

On a machine that doesn't already contain a copy of this repo in `$HOME/.dotfiles`, run:
    /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/itsmycargo/dotfiles/master/install)"
